### PR TITLE
Allow Weapons without SlotNumber

### DIFF
--- a/ZScript/MC/WeaponSwitch.txt
+++ b/ZScript/MC/WeaponSwitch.txt
@@ -39,6 +39,45 @@ Class MCWeaponList play
 {
 	Array<Class<Weapon> > Weapons;
 	
+	int GetSlotNumber(readonly<Weapon> defwep)
+	{
+		if(!defwep)
+			return -1;
+		if(defwep.SlotNumber>=0&&defwep.SlotNumber<=9)
+			return defwep.SlotNumber;
+		//If the weapon didn't define a slotnumber, check the playerclasses
+		//to see if one of them has it as a weaponslot
+		int playerend=PlayerClasses.Size();
+
+		string thisslot;
+			int theseweaponssize,found;
+		Array<String> theseweapons;
+			let wepname=defwep.GetClassName();
+
+		for(int i=0;i<playerend;i++)
+		{
+			//Check this playerclass to see if the weapon's in its slots
+			let playerclass=(class<PlayerPawn>)(PlayerClasses[i].type);
+			let playerdef=GetDefaultByType(playerclass);
+			for(int j=0;j<=9;j++)
+			{
+				//Split this slot into a string array
+				thisslot=playerdef.slot[j];
+				thisslot.Split(theseweapons," ");
+				theseweaponssize=theseweapons.size();
+				found=theseweapons.find(wepname);
+				//If this weapon's name is in this array (is an item in this weaponslot)
+				//Choose this to be its slot for all other purposes!
+				if(found<theseweaponssize)
+					return j;
+				//If not, clear that array and try again
+				theseweapons.clear();
+			}
+		}
+		//Still didn't find a slot in all those players?
+		//Weapon must not be slotted anywhere. Let's kill it...
+		return -1;
+	}
 	void Init()
 	{
 		// First, just get all weapon valid classes.
@@ -52,10 +91,10 @@ Class MCWeaponList play
 			if (!wep)	continue;
 			
 			// Skip all bad assignments.
-			let def = GetDefaultByType(wep);
-			if (def.SlotNumber < 0 || def.SlotNumber > 9 || 
-				def.SlotPriority > 1.0 || def.SlotPriority < 0.0)
-				continue;
+			//let def = GetDefaultByType(wep);
+			//if (def.SlotNumber < 0 || def.SlotNumber > 9 || 
+				//def.SlotPriority > 1.0 || def.SlotPriority < 0.0)
+				//continue;
 				
 			Weapons.Push(wep);
 		}
@@ -76,8 +115,8 @@ Class MCWeaponList play
 			{
 				let UnDef = GetDefaultByType(Weapons[j]);
 				let WeDef = GetDefaultByType(Weapons[j + 1]);
-				int UnSlot = UnDef.SlotNumber;
-				int WeSlot = WeDef.SlotNumber;
+				int UnSlot = GetSlotNumber(UnDef);
+				int WeSlot = GetSlotNumber(WeDef);
 				
 				// Put slot 0 weapons at the top by faking them to be 10.
 				if (UnSlot == 0)	UnSlot = 10;

--- a/ZScript/MC/WeaponSwitch.txt
+++ b/ZScript/MC/WeaponSwitch.txt
@@ -39,12 +39,21 @@ Class MCWeaponList play
 {
 	Array<Class<Weapon> > Weapons;
 	
-	int GetSlotNumber(readonly<Weapon> defwep)
+	int,double GetSlotNumber(readonly<Weapon> defwep)
 	{
+		//Just in case we somehow called this with an invalid weapon
 		if(!defwep)
-			return -1;
+			return -1,-1.0;
+		//If the weapon does have a SlotNumber defined, use that
+
+		//We can possibly manage if no Priority is set, so let's get that now...
+		double slotprio=-1.0;
+		if(defwep.SlotPriority>=0.0&&defwep.SlotPriority<=1.0)
+			slotprio=defwep.SlotPriority;
+		//Now the slot itself...
 		if(defwep.SlotNumber>=0&&defwep.SlotNumber<=9)
-			return defwep.SlotNumber;
+			return defwep.SlotNumber,slotprio;
+
 		//If the weapon didn't define a slotnumber, check the playerclasses
 		//to see if one of them has it as a weaponslot
 		int playerend=PlayerClasses.Size();
@@ -69,7 +78,17 @@ Class MCWeaponList play
 				//If this weapon's name is in this array (is an item in this weaponslot)
 				//Choose this to be its slot for all other purposes!
 				if(found<theseweaponssize)
-					return j;
+				{
+					double temppriority=0.0;
+					//First item in the array? Highest priority
+					//Else, check against the size of this slot
+					if(found!=0)
+					{
+						double dfound=found,dtotal=theseweaponssize-1;
+						temppriority=dfound/dtotal;
+					}
+					return j,temppriority;
+				}
 				//If not, clear that array and try again
 				theseweapons.clear();
 			}
@@ -115,9 +134,11 @@ Class MCWeaponList play
 			{
 				let UnDef = GetDefaultByType(Weapons[j]);
 				let WeDef = GetDefaultByType(Weapons[j + 1]);
-				int UnSlot = GetSlotNumber(UnDef);
-				int WeSlot = GetSlotNumber(WeDef);
-				
+				int UnSlot,WeSlot;
+				double UnPriority,WePriority;
+				[UnSlot,UnPriority] = GetSlotNumber(UnDef);
+				[WeSlot,WePriority] = GetSlotNumber(WeDef);
+
 				// Put slot 0 weapons at the top by faking them to be 10.
 				if (UnSlot == 0)	UnSlot = 10;
 				if (WeSlot == 0)	WeSlot = 10;
@@ -134,7 +155,7 @@ Class MCWeaponList play
 				// positions. as needed.
 				else if (UnSlot == WeSlot)
 				{
-					if (UnDef.SlotPriority > WeDef.SlotPriority)
+					if (UnPriority > WePriority)
 					{
 						Swap(j, j+1);
 					}


### PR DESCRIPTION
If a weapon has no SlotNumber, check all existing playerclasses, see if one of them has the weapon in a WeaponSlot, and use that number.

Note: No work has been done on SlotPriority yet...