### PR TITLE
 Don't override Map commands

### DIFF
--- a/ZScript/MC/Base.txt
+++ b/ZScript/MC/Base.txt
@@ -177,7 +177,10 @@ Class MCHandler : EventHandler
 			{
 				// Bindings is a global struct. Definition in menu.txt inside GZDoom.pk3.
 				// Get the keys that are bound to this action.
-				[bind1, bind2] = Bindings.GetKeysForCommand (KeyBindsCCMDs [i]);
+				if(automapactive)
+					[bind1, bind2] = AutomapBindings.GetKeysForCommand (KeyBindsCCMDs [i]);
+				else
+					[bind1, bind2] = Bindings.GetKeysForCommand (KeyBindsCCMDs [i]);
 				
 				if (ev.KeyScan == bind1 || ev.KeyScan == bind2) 
 				{


### PR DESCRIPTION
Now the zoom function (default) works again